### PR TITLE
fix: upsert endpoint correction

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -962,7 +962,7 @@ export class Index {
 
   public async upsertDocuments<T = AnyObject[]>(documents: T, init?: ClientRequestInit): Promise<void> {
     await this.oramaInterface.request<void>({
-      path: `/v1/collections/${this.collectionID}/indexes/${this.indexID}/upsert`,
+      path: `/v1/collections/${this.collectionID}/indexes/${this.indexID}/documents/upsert`,
       body: documents as AnyObject[],
       method: 'POST',
       init,


### PR DESCRIPTION
Changed the `upsertDocuments` method in `src/collection.ts` to use the `/documents/upsert`