### PR TITLE
Fix: update upsertDocuments to use merge strategy for document insertion

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -963,7 +963,10 @@ export class Index {
   public async upsertDocuments<T = AnyObject[]>(documents: T, init?: ClientRequestInit): Promise<void> {
     await this.oramaInterface.request<void>({
       path: `/v1/collections/${this.collectionID}/indexes/${this.indexID}/documents/upsert`,
-      body: documents as AnyObject[],
+      body: {
+        strategy: "merge",
+        documents: documents as AnyObject[]
+      },
       method: 'POST',
       init,
       apiKeyPosition: 'header',


### PR DESCRIPTION
This pull request updates the `upsertDocuments` method in the `Index` class to fix how documents are sent to the `upsert` endpoint in the API.